### PR TITLE
[feat] create contact page

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,4 +1,4 @@
-<div class="container"> 
+<section> 
   <h4 id="contact">CONTACT US</h4>
   <div class="spacer"></div>
   <div class="row">
@@ -13,10 +13,10 @@
     if you need a particular accommodation.
     Note that requests made less than 24 hours before the event will likely not be accommodated.
   </p>
-</div>
+</section>
 
 <style lang="scss">
-  div.container {
+  section {
     display: flex;
     flex-direction: column;
     align-items: center; 
@@ -38,7 +38,6 @@
   }
 
   a.email {
-    line-height: 150%;
     text-decoration-line: underline; // the underline is too close to the text... 
   }
 </style>

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -60,6 +60,7 @@ a {
   color: colors.$link;
   text-decoration: none;
   font-weight: 700;
+  line-height: 150%;
 }
 
 button {


### PR DESCRIPTION
### What's new?
[//]: # "Describe what's new in a few lines or bullet points. Feel free to add screenshots!"
* created contact page 
* updated p tag in _global.scss (added font-weight: 400; letter-spacing: 0.8px)

Up for Discussion 
* the underline for the links looks wonky (too close), compared to figma (see below)
* currently, the container div is set to 46.5rem, per the desktop design on figma. 
    * not sure how to make it more compatible for diff screen sizes (how are we supposed to use _breakpoints.scss?)

Current: 
<img width="677" alt="Screen Shot 2024-01-10 at 1 53 25 PM" src="https://github.com/calblueprint/hack-for-impact/assets/64336644/c5eeb4c6-4afe-483d-be66-035c441498c5">
Compare to: Figma 
<img width="433" alt="Screen Shot 2024-01-10 at 1 57 14 PM" src="https://github.com/calblueprint/hack-for-impact/assets/64336644/131d8fcf-27d4-4900-93d6-d6c18c57db57">


#### Linear Task
[//]: # "Link the Linear task that this PR finishes for sake of organization"
https://linear.app/hack-for-impact-2024/issue/HFI-19/contact-us-section