### PR TITLE
[feat] create about section (Our Vision, The Mission)

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -7,34 +7,35 @@
       <h3>&nbsp;at UC Berkeley to innovate for social good.</h3>
   </div>
 
-  
-  <div class="bigRow">
-    <h2 class="left">Our Vision</h2>
-    <p>To solve the most pressing challenges of our world, 
-      we will need the best and the brightest minds to work collaboratively on 
-      creative, ethical, and technical solutions that will propel humanity forward. 
-      Our audience is anyone, anywhere, who believes that 
-      technology can solve hard problems, grow prosperity, 
-      and expand human possibilities.</p>
-  </div>
-  <div class="bigRow">
-    <h2 class="left">The Mission</h2>
-    <div>
-      <p>Hack for Impact 2024 is a 1-day hackathon co-hosted by 
-        Blueprint and Cal Hacks at UC Berkeley. 
-        The event’s mission is two-fold:</p>
-      <div class="captionRow">
-        <div class="image-placeholder"></div>
-        <p>To <b>empower</b> student hackers to develop creative solutions 
-          for relevant social causes and collaborate with 
-          non-profit organizations on ethical innovation 
-          with tangible community impact.</p>
-      </div>
-      <div class="captionRow">
-        <div class="image-placeholder"></div>
-        <p>To <b>educate</b> students via a <b>series of workshops and speaker panels</b> 
-          to learn about professional opportunities in social good, 
-          as well as emerging technologies and their ethical aspects.</p>
+  <div class="mission-vision">
+    <div class="bigRow">
+      <h2 class="left">Our Vision</h2>
+      <p>To solve the most pressing challenges of our world, 
+        we will need the best and the brightest minds to work collaboratively on 
+        creative, ethical, and technical solutions that will propel humanity forward. 
+        Our audience is anyone, anywhere, who believes that 
+        technology can solve hard problems, grow prosperity, 
+        and expand human possibilities.</p>
+    </div>
+    <div class="bigRow">
+      <h2 class="left">The Mission</h2>
+      <div>
+        <p>Hack for Impact 2024 is a 1-day hackathon co-hosted by 
+          Blueprint and Cal Hacks at UC Berkeley. 
+          The event’s mission is two-fold:</p>
+        <div class="captionRow">
+          <div class="image-placeholder"></div>
+          <p>To <b>empower</b> student hackers to develop creative solutions 
+            for relevant social causes and collaborate with 
+            non-profit organizations on ethical innovation 
+            with tangible community impact.</p>
+        </div>
+        <div class="captionRow">
+          <div class="image-placeholder"></div>
+          <p>To <b>educate</b> students via a <b>series of workshops and speaker panels</b> 
+            to learn about professional opportunities in social good, 
+            as well as emerging technologies and their ethical aspects.</p>
+        </div>
       </div>
     </div>
   </div>
@@ -47,12 +48,16 @@
     flex-direction: column;
     align-items: center; 
     text-align: center;
-    max-width: 58.625rem;
+    width: 100%;
     margin: 0 auto;
     padding-top: 5rem;
   }
   div.spacer {
     height: 1.5rem;
+  }
+
+  div.mission-vision {
+    max-width: 58.625rem;
   }
 
   div.bigRow {


### PR DESCRIPTION
### What's new?
[//]: # "Describe what's new in a few lines or bullet points. Feel free to add screenshots!"
* creates the 2nd half of about i.e. Our Vision, The Mission
* ~~adds b in _global.css~~

N.B. 
* The description next to Our Vision and The Mission have a font-weight of 600 in the figma description, but I kept it as a normal p tag (font-weight = 500), since it's visually more similar to the design.
* the captions next to the images under The Mission: current implementation has them flush against the outer div, but the figma version seems to have slightly more padding on the right.

Current: 
<img width="1013" alt="Screen Shot 2024-01-10 at 11 08 12 PM" src="https://github.com/calblueprint/hack-for-impact/assets/64336644/f614d839-845f-4c9c-95f4-f6f79c9bb171">
Compare to Figma: 
<img width="443" alt="Screen Shot 2024-01-10 at 11 09 49 PM" src="https://github.com/calblueprint/hack-for-impact/assets/64336644/231fa03a-da8d-4b2d-a8d2-7f139a7a01a1">

#### Linear Task
[//]: # "Link the Linear task that this PR finishes for sake of organization"
https://linear.app/hack-for-impact-2024/issue/HFI-14/about-section