### PR TITLE
[feat] add Graphics To Nonprofits Section + Patch Design

### DIFF
--- a/src/components/NonProfit.astro
+++ b/src/components/NonProfit.astro
@@ -34,7 +34,9 @@ const { name, description, image, startColor, endColor, url } = Astro.props;
     position: relative;
     overflow: hidden;
     border-radius: 12px;
-    padding-top: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
 
     .bg {
       position: absolute;
@@ -56,7 +58,6 @@ const { name, description, image, startColor, endColor, url } = Astro.props;
 
     a {
       width: 100%;
-      padding: 32px;
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
@@ -64,9 +65,11 @@ const { name, description, image, startColor, endColor, url } = Astro.props;
       color: white;
       font-weight: 400;
       line-height: 100%;
+      padding: 32px;
+      padding-top: 120px;
 
       @media (min-width: breakpoints.$laptop) {
-        padding-top: 0;
+        padding-top: 32px;
         aspect-ratio: 10 / 9;
       }
     }

--- a/src/components/NonProfits.astro
+++ b/src/components/NonProfits.astro
@@ -103,8 +103,7 @@ import clouds from '../graphics/clouds_star_twirl_2.svg';
 
   .nonprofits {
     width: 100%;
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding: 0 10%;
     position: relative;
     display: grid;
     grid-template-rows: min-content;


### PR DESCRIPTION
### What's new?

Adds the graphics!

<img width="1204" alt="Screenshot 2024-01-12 at 11 15 35 PM" src="https://github.com/calblueprint/hack-for-impact/assets/39828164/6fe965d4-7e12-4b86-a976-aae1ab950127">

#### Linear Task

https://linear.app/hack-for-impact-2024/issue/HFI-29/nonprofits-section-graphics
