### PR TITLE
[fix] move schedule before npo

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,8 +7,8 @@ import Hero from './Hero.astro';
   <NavBar
     links={[
       { name: 'ABOUT', url: '#about' },
-      { name: 'NONPROFITS', url: '#nonprofits' },
       { name: 'SCHEDULE', url: '#schedule' },
+      { name: 'NONPROFITS', url: '#nonprofits' },
       { name: 'FAQ', url: '#faq' },
       { name: 'CONTACT', url: '#contact' },
     ]}


### PR DESCRIPTION
### What's new?
[//]: # "Describe what's new in a few lines or bullet points. Feel free to add screenshots!"

![image](https://github.com/calblueprint/hack-for-impact/assets/67077248/262144db-4cc6-4e21-8733-b497233f3c03)


#### Linear Task
[//]: # "Link the Linear task that this PR finishes for sake of organization"

https://linear.app/hack-for-impact-2024/issue/HFI-46/reorient-navbar-links-move-schedule-before-npo