### PR TITLE
[fix] mobile navbar menu backdrop

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -67,7 +67,9 @@ export default function NavBar({ links }: Props) {
       </button>
 
       {/* backdrop */}
-      <div className={styles.backdrop}></div>
+      <div
+        className={`${styles.backdrop} ${menuVisible ? styles.show : null}`}
+      ></div>
 
       {/* links */}
       <section className={styles.links}>

--- a/src/components/Navbar/style.module.scss
+++ b/src/components/Navbar/style.module.scss
@@ -65,9 +65,15 @@ nav {
   width: 100%;
   height: 100%;
   z-index: 9;
+  transition: 1s;
+
+  &.show {
+    background: white;
+    transition: 0s;
+  }
 
   @media (min-width: breakpoints.$tablet) {
-    visibility: hidden;
+    background: none !important;
   }
 }
 


### PR DESCRIPTION
### What's new?
[//]: # "Describe what's new in a few lines or bullet points. Feel free to add screenshots!"

- Made navbar backdrop white when mobile menu expands

![image](https://github.com/calblueprint/hack-for-impact/assets/67077248/7172b5f7-89c7-41d2-8b25-dd0a4c63d12a)


#### Linear Task
[//]: # "Link the Linear task that this PR finishes for sake of organization"

https://linear.app/hack-for-impact-2024/issue/HFI-53/fix-nav-bar-mobile-menu